### PR TITLE
Fix missing notification util

### DIFF
--- a/screens/ChatScreen.js
+++ b/screens/ChatScreen.js
@@ -21,7 +21,7 @@ import {
 import { getMemories, saveMemory } from "../utils/memoryStore";
 import { extractTasks } from "../utils/taskExtractor";
 import { addTask } from "../utils/taskStore";
-import { scheduleNotificationWithId } from "./HomeScreen";
+import { scheduleNotificationWithId } from "../utils/notifications";
 
 export default function ChatScreen() {
   const navigation = useNavigation();

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1,0 +1,37 @@
+import * as Notifications from 'expo-notifications';
+
+/**
+ * Schedule a local notification and return its identifier.
+ * @param {string} text - Notification body text.
+ * @param {string|null} date - ISO date string (YYYY-MM-DD) or null.
+ * @param {string|null} time - Time string (HH:mm) or null.
+ * @returns {Promise<string|null>} Scheduled notification identifier or null.
+ */
+export async function scheduleNotificationWithId(text, date, time) {
+  if (!date) {
+    return null;
+  }
+
+  try {
+    const triggerDate = new Date(date);
+    if (time) {
+      const [hour, minute] = time.split(':').map(Number);
+      if (!Number.isNaN(hour) && !Number.isNaN(minute)) {
+        triggerDate.setHours(hour, minute, 0, 0);
+      }
+    }
+
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: '알림',
+        body: text,
+      },
+      trigger: triggerDate,
+    });
+
+    return id;
+  } catch (e) {
+    console.warn('scheduleNotificationWithId 실패:', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- create `utils/notifications.js` to schedule notifications
- import the new util in `ChatScreen`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155231f7c832598979e453237987a